### PR TITLE
Remove containerd as TSC represented project

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,5 @@ tsc@mobyproject.org
 * [LinuxKit](https://github.com/linuxkit/linuxkit)
 * [Moby](https://github.com/moby/moby)
 * [SwarmKit](https://github.com/docker/swarmkit)
-* [containerd](https://github.com/containerd/containerd)
 * [libnetwork](https://github.com/docker/libnetwork)
 * [notary](https://github.com/docker/notary)

--- a/REPRESENTATIVES.md
+++ b/REPRESENTATIVES.md
@@ -7,8 +7,6 @@ List of representative for each project that will cast the ballot:
 	- Brian Goff brian.goff@docker.com
 * [SwarmKit](https://github.com/docker/swarmkit)
   - Nishant Totla nishanttotla@gmail.com
-* [containerd](https://github.com/containerd/containerd)
-	- Michael Crosby michael@docker.com
 * [libnetwork](https://github.com/docker/libnetwork)
 	- Madhu Venugopal madhu@docker.com
 * [notary](https://github.com/docker/notary)


### PR DESCRIPTION
containerd has voted to remove the use of the TSC for technical dispute resolution.

See https://github.com/containerd/project/pull/16
