### PR TITLE
Remove Stefan Scherer per his request

### DIFF
--- a/MEMBERS.md
+++ b/MEMBERS.md
@@ -5,7 +5,6 @@
 * Phil Estes estesp@gmail.com
 * Laura Frank ljfrank@gmail.com
 * Justin Cormack justin.cormack@docker.com
-* Stefan Scherer scherer_stefan@icloud.com
 * Tianon Gravi admwiggin@gmail.com
 * Arnaud Porterie arnaud.porterie@gmail.com
 * Sebastiaan van Stijn sebastiaan.vanstijn@docker.com


### PR DESCRIPTION
Upon joining Docker, Stefan notified the TSC that he would be stepping
down per Moby TSC guidelines of only 2 members per company (based on
current TSC size).

Thanks Stefan for your service!

Fixes: #21 

Signed-off-by: Phil Estes <estesp@linux.vnet.ibm.com>